### PR TITLE
Ensure the ConfigService is fully loaded before setting the service provider

### DIFF
--- a/src/main/java/me/morpheus/metropolis/config/ConfigUtil.java
+++ b/src/main/java/me/morpheus/metropolis/config/ConfigUtil.java
@@ -39,10 +39,6 @@ public final class ConfigUtil {
         createDir(RANK);
         createDir(FLAG);
         createDir(TOWN_TYPE);
-
-        if (Files.notExists(CONF)) {
-            Files.createFile(CONF);
-        }
     }
 
     private static void createDir(Path path) throws IOException {


### PR DESCRIPTION
By async loading the config file we need to ensure the ConfigService is added to the ServiceProvider **after** being fully loaded.
Adding a service provider means firing an event, so it needs to be done on the main thread.

This commit also avoid reloading the config if there's no config file when starting the server.